### PR TITLE
Fix authentication localhost reference

### DIFF
--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,7 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.REACT_APP_SUPABASE_URL || 'https://your-project.supabase.co';
-const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY || 'your-anon-key';
+const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
+const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Supabase configuration missing: set REACT_APP_SUPABASE_URL and REACT_APP_SUPABASE_ANON_KEY in your environment.');
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 


### PR DESCRIPTION
Enforce Supabase client configuration via environment variables to prevent incorrect authentication endpoints.

Previously, the Supabase client used placeholder values if environment variables were not set, which could lead to authentication attempts against incorrect URLs, such as `localhost:3000`, instead of the configured Supabase instance.

---
<a href="https://cursor.com/background-agent?bcId=bc-3730429e-664d-4870-9c1b-eceb5c7464af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3730429e-664d-4870-9c1b-eceb5c7464af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

